### PR TITLE
Removed string comparison check for parseDay

### DIFF
--- a/timer.js
+++ b/timer.js
@@ -25,8 +25,7 @@ var timer = (function () {
     }
 
     function parseDay(d) {
-        var str = d.toString();
-        if(str[str.length-2] == 1) /* force 12th not 12nd */
+        if(Math.floor((d/10)%10) == 1) /* force 12th not 12nd */
             return d+"th";
         
         switch (d%10) {


### PR DESCRIPTION
Lets us do the ordinal tests without having to create a string

(Just wanted to try doing a fork + PR - you don't have to accept if you don't want to)
