### PR TITLE
Increase forkmeness, use built-ins for Date parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <script src="timer.js"></script> 
   </head>
   <body>
+  <a href="https://github.com/rcrimp/countdown-timer"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
     <div class="section">
       <h2>100 level</h2>
       <div id="comp160" class="timer"></div>
@@ -25,7 +26,5 @@
       <div id="cosc348" class="timer"></div>
       <div id="cosc345" class="timer"></div>
     </div>
-
-    <a href="https://github.com/rcrimp/countdown-timer">Github</a>
   </body>
 </html>

--- a/timer.js
+++ b/timer.js
@@ -34,9 +34,9 @@ var timer = (function () {
     function updateTimer(date, name) {
         /* diff = time remaining in milliseconds */
         var diff = date.getTime() - (new Date()).getTime();
-        if (diff < 0)
+        if (diff < 0) {
             $("#"+name).html("<h3>" + name + "</h3><p>expired</p>");
-        else {
+        } else {
             var days = Math.floor(diff / day);
             diff -= days*day;
             var hours = Math.floor(diff / hour);

--- a/timer.js
+++ b/timer.js
@@ -60,55 +60,25 @@ var timer = (function () {
         }, 1000);
     }
     
-    /* roughly "YYYY-MM-DD HH:MM:SS"" */
-    function dateBuilder(dateTimeString) {
-        
-        var dateTimeComponents = dateTimeString.split(" ");
-        
-        var dateComponent = dateTimeComponents[0];
-        
-        var timeComponent = dateTimeComponents[1];
-        
-        var dateComponents = dateComponent.split("-");
-        
-        var timeComponents = timeComponent.split(":");
-        
-        var year = dateComponents[0];
-        
-        var month = dateComponents[1];
-        
-        // Off-by-one hack for Javascript's Date implementation
-        month--;
-        
-        var day = dateComponents[2];
-        
-        var hour = timeComponents[0];
-        var minute = timeComponents[1];
-        var second = timeComponents[2];
-        
-        // Hard-code zero milliseconds
-        return new Date(year, month, day, hour, minute, second, 0);
-    };
-
     pub.setup = function () {
 
         // just encode as key-value pair since we have no interfaces etc
         var examSchedule = {
-            "cosc344": "2015-10-17 09:30:00",
-            "cosc346": "2015-10-19 09:30:00",
-            "cosc244": "2015-10-27 14:30:00",
-            "cosc348": "2015-10-29 09:30:00",
-            "cosc242": "2015-10-29 09:30:00",
-            "cosc345": "2015-10-31 09:30:00",
-            "comp212": "2015-11-03 09:30:00",
-            "comp160": "2015-11-06 09:30:00"
+            "cosc344": "2015-10-17T09:30:00",
+            "cosc346": "2015-10-19T09:30:00",
+            "cosc244": "2015-10-27T14:30:00",
+            "cosc348": "2015-10-29T09:30:00",
+            "cosc242": "2015-10-29T09:30:00",
+            "cosc345": "2015-10-31T09:30:00",
+            "comp212": "2015-11-03T09:30:00",
+            "comp160": "2015-11-06T09:30:00"
         };
 
         for (var exam in examSchedule) {
 
             var examDateTimeString = examSchedule[exam];
 
-            var examDateTimeObject = dateBuilder(examDateTimeString);
+            var examDateTimeObject = new Date(examDateTimeString);
 
             setupTimer(examDateTimeObject, exam);
         }


### PR DESCRIPTION
By providing good data (ISO format dates), we can remove our custom Date parser and use the standard mechanism.
